### PR TITLE
WeightedVote 機能追加

### DIFF
--- a/contracts/MockERC20.sol
+++ b/contracts/MockERC20.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockERC20
+/// @notice テスト用に自由にミントできるシンプルなERC20トークン
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    /// @notice 任意のアドレスへトークンを発行
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+

--- a/contracts/WeightedVote.sol
+++ b/contracts/WeightedVote.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title WeightedVote
+ * @notice トークン量に応じた重み付き投票を行うコントラクトです。
+ * DynamicVote を基に、投票時に ERC20 トークンを預け入れます。
+ */
+contract WeightedVote is Ownable {
+    /// 投票に使うトークン
+    IERC20 public immutable token;
+    /// 議題
+    string public topic;
+    /// 選択肢 ID => 選択肢名
+    mapping(uint256 => string) public choice;
+    /// アドレス => 投票した選択肢 ID (0 は未投票)
+    mapping(address => uint256) public votedChoiceId;
+    /// 選択肢 ID => 票数
+    mapping(uint256 => uint256) public voteCount;
+    /// 各アドレスが預けたトークン量
+    mapping(address => uint256) public deposited;
+    /// 選択肢の総数（最大 10）
+    uint256 public choiceCount;
+
+    event ChoiceAdded(uint256 id, string name);
+    event VoteCast(address voter, uint256 choiceId, uint256 amount);
+    event VoteCancelled(address indexed voter, uint256 choiceId, uint256 amount);
+
+    /// @param _topic 議題
+    /// @param _token 投票に利用する ERC20 トークン
+    constructor(string memory _topic, IERC20 _token) Ownable(msg.sender) {
+        topic = _topic;
+        token = _token;
+    }
+
+    /**
+     * @notice 新しい選択肢を追加します。オーナーのみ実行可能です。
+     * @param name 選択肢の名前
+     */
+    function addChoice(string calldata name) external onlyOwner {
+        require(choiceCount < 10, "too many choices");
+        uint256 id = ++choiceCount;
+        choice[id] = name;
+        emit ChoiceAdded(id, name);
+    }
+
+    /**
+     * @notice トークンを預け入れて投票します。
+     * @param choiceId 1 から choiceCount までの選択肢 ID
+     * @param amount 預けるトークン量（そのまま票数となります）
+     */
+    function vote(uint256 choiceId, uint256 amount) external {
+        require(votedChoiceId[msg.sender] == 0, "Already voted. Cancel first");
+        require(choiceId > 0 && choiceId <= choiceCount, "invalid id");
+        require(amount > 0, "amount zero");
+
+        require(token.transferFrom(msg.sender, address(this), amount));
+        voteCount[choiceId] += amount;
+        deposited[msg.sender] = amount;
+        votedChoiceId[msg.sender] = choiceId;
+        emit VoteCast(msg.sender, choiceId, amount);
+    }
+
+    /// @notice 投票を取り消し、預けたトークンを返却します
+    function cancelVote() external {
+        uint256 prev = votedChoiceId[msg.sender];
+        require(prev != 0, "No vote to cancel");
+        uint256 amount = deposited[msg.sender];
+        voteCount[prev] -= amount;
+        deposited[msg.sender] = 0;
+        votedChoiceId[msg.sender] = 0;
+        require(token.transfer(msg.sender, amount));
+        emit VoteCancelled(msg.sender, prev, amount);
+    }
+
+    /// @notice 全選択肢の名前を配列で取得
+    function getChoices() external view returns (string[] memory names) {
+        names = new string[](choiceCount);
+        for (uint256 i = 0; i < choiceCount; i++) {
+            names[i] = choice[i + 1];
+        }
+    }
+}
+

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -34,6 +34,15 @@ async function main() {
     await weighted.addChoice('Blue');
     console.log('WeightedVote deployed to:', weighted.target);
     console.log('VoteToken deployed to:', token.target);
+
+    // フロントエンドの WeightedVote アドレスを書き換え
+    data = fs.readFileSync(constantsPath, 'utf8');
+    data = data.replace(
+        /export const WEIGHTED_VOTE_ADDRESS = '0x[0-9a-fA-F]+';/,
+        `export const WEIGHTED_VOTE_ADDRESS = '${weighted.target}';`
+    );
+    fs.writeFileSync(constantsPath, data);
+    console.log('Updated WEIGHTED_VOTE_ADDRESS in constants.js');
 }
 
 main().catch((error) => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -7,6 +7,21 @@ async function main() {
     await vote.addChoice('Cats');
     await vote.addChoice('Dogs');
     console.log('DynamicVote deployed to:', vote.target);
+
+    // WeightedVote 用のトークンをデプロイ
+    const Token = await hre.ethers.getContractFactory('MockERC20');
+    const token = await Token.deploy('VoteToken', 'VTK');
+    await token.waitForDeployment();
+    const [deployer] = await hre.ethers.getSigners();
+    await token.mint(deployer.address, hre.ethers.parseEther('1000'));
+
+    const Weighted = await hre.ethers.getContractFactory('WeightedVote');
+    const weighted = await Weighted.deploy('Best color', token.target);
+    await weighted.waitForDeployment();
+    await weighted.addChoice('Red');
+    await weighted.addChoice('Blue');
+    console.log('WeightedVote deployed to:', weighted.target);
+    console.log('VoteToken deployed to:', token.target);
 }
 
 main().catch((error) => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,4 +1,6 @@
 const hre = require('hardhat');
+const fs = require('fs');
+const path = require('path');
 
 async function main() {
     const Vote = await hre.ethers.getContractFactory('DynamicVote');
@@ -7,6 +9,16 @@ async function main() {
     await vote.addChoice('Cats');
     await vote.addChoice('Dogs');
     console.log('DynamicVote deployed to:', vote.target);
+
+    // フロントエンドのアドレスを書き換え
+    const constantsPath = path.join(__dirname, '..', 'simple-vote-ui', 'src', 'constants.js');
+    let data = fs.readFileSync(constantsPath, 'utf8');
+    data = data.replace(
+        /export const DYNAMIC_VOTE_ADDRESS = '0x[0-9a-fA-F]+';/,
+        `export const DYNAMIC_VOTE_ADDRESS = '${vote.target}';`
+    );
+    fs.writeFileSync(constantsPath, data);
+    console.log('Updated DYNAMIC_VOTE_ADDRESS in constants.js');
 
     // WeightedVote 用のトークンをデプロイ
     const Token = await hre.ethers.getContractFactory('MockERC20');

--- a/simple-vote-ui/src/App.jsx
+++ b/simple-vote-ui/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { ethers } from 'ethers';
 import { DYNAMIC_VOTE_ABI, DYNAMIC_VOTE_ADDRESS } from './constants';
+import WeightedVote from './WeightedVote.jsx';
 
 function App() {
     const [signer, setSigner] = useState(null);
@@ -153,6 +154,7 @@ function App() {
                     {txPending && <p>トランザクション承認待ち…</p>}
                 </>
             )}
+            {signer && <WeightedVote signer={signer} />}
         </main>
     );
 }

--- a/simple-vote-ui/src/WeightedVote.jsx
+++ b/simple-vote-ui/src/WeightedVote.jsx
@@ -1,0 +1,182 @@
+import { useEffect, useState, useCallback } from 'react';
+import { ethers } from 'ethers';
+import {
+    WEIGHTED_VOTE_ABI,
+    WEIGHTED_VOTE_ADDRESS,
+    ERC20_ABI,
+} from './constants';
+
+function WeightedVote({ signer }) {
+    const [contract, setContract] = useState(null);
+    const [token, setToken] = useState(null);
+    const [topic, setTopic] = useState('');
+    const [choices, setChoices] = useState([]);
+    const [selected, setSelected] = useState(null);
+    const [amount, setAmount] = useState('');
+    const [votedId, setVotedId] = useState(0);
+    const [txPending, setTxPending] = useState(false);
+
+    // signer が変わったらコントラクトを初期化
+    useEffect(() => {
+        if (!signer) return;
+        const vote = new ethers.Contract(
+            WEIGHTED_VOTE_ADDRESS,
+            WEIGHTED_VOTE_ABI,
+            signer
+        );
+        setContract(vote);
+        (async () => {
+            const tokenAddr = await vote.token();
+            const tok = new ethers.Contract(tokenAddr, ERC20_ABI, signer);
+            setToken(tok);
+        })();
+    }, [signer]);
+
+    // 投票状況を取得
+    const fetchData = useCallback(async () => {
+        if (!contract) return;
+        setTopic(await contract.topic());
+        const count = await contract.choiceCount();
+        const arr = [];
+        for (let i = 1n; i <= count; i++) {
+            const name = await contract.choice(i);
+            const votes = await contract.voteCount(i);
+            // トークンの票数は 18 桁の精度を持つので、Ether 表記へ変換
+            const formatted = ethers.formatEther(votes);
+            arr.push({ id: Number(i), name, votes: formatted });
+        }
+        setChoices(arr);
+        if (signer) {
+            const addr = await signer.getAddress();
+            const id = await contract.votedChoiceId(addr);
+            setVotedId(Number(id));
+
+            // 取得した投票情報をコンソールに表示
+            console.log('=== WeightedVote 投票状態 ===');
+            console.log('ユーザーアドレス:', addr);
+            console.log('投票済み選択肢ID:', Number(id));
+            console.log('投票済みかどうか:', Number(id) !== 0);
+            if (Number(id) !== 0) {
+                const votedChoice = arr.find((c) => c.id === Number(id));
+                console.log('投票した選択肢:', votedChoice ? votedChoice.name : '不明');
+            }
+            console.log('選択肢一覧:', arr);
+            console.log('================');
+        }
+    }, [contract, signer]);
+
+    // 初期化とイベント購読
+    useEffect(() => {
+        if (!contract) return;
+        fetchData();
+        contract.on('VoteCast', fetchData);
+        contract.on('VoteCancelled', fetchData);
+        return () => {
+            contract.off('VoteCast', fetchData);
+            contract.off('VoteCancelled', fetchData);
+        };
+    }, [contract, fetchData]);
+
+    // トークンの承認
+    const approve = async () => {
+        if (!token || !amount) return;
+        const value = ethers.parseEther(amount);
+        const tx = await token.approve(WEIGHTED_VOTE_ADDRESS, value);
+        await tx.wait();
+    };
+
+    // 投票処理
+    const vote = async () => {
+        if (!contract || selected === null || !amount) return;
+        try {
+            setTxPending(true);
+            const value = ethers.parseEther(amount);
+            const tx = await contract.vote(selected, value);
+            await tx.wait();
+            await fetchData();
+        } finally {
+            setTxPending(false);
+        }
+    };
+
+    // 投票取消
+    const cancelVote = async () => {
+        if (!contract) return;
+        try {
+            setTxPending(true);
+            const tx = await contract.cancelVote();
+            await tx.wait();
+            await fetchData();
+        } finally {
+            setTxPending(false);
+        }
+    };
+
+    return (
+        <section className="flex flex-col items-center gap-4 mt-10">
+            <h2 className="text-2xl font-bold">WeightedVote DApp</h2>
+            <p className="text-lg">議題: {topic}</p>
+            <form
+                className="flex flex-col gap-2"
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    vote();
+                }}
+            >
+                {choices.map((c) => (
+                    <label key={c.id} className="flex items-center gap-2">
+                        <input
+                            type="radio"
+                            name="weightedChoice"
+                            value={c.id}
+                            onChange={() => setSelected(c.id)}
+                            checked={selected === c.id}
+                            disabled={votedId !== 0}
+                        />
+                        {c.name} ({c.votes})
+                    </label>
+                ))}
+                <input
+                    type="number"
+                    min="0"
+                    placeholder="トークン量"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                    className="border px-2 py-1 rounded"
+                    disabled={votedId !== 0}
+                />
+                <button
+                    type="button"
+                    className="px-4 py-2 rounded-xl bg-green-500 text-white disabled:opacity-50"
+                    onClick={approve}
+                    disabled={!amount || selected === null || votedId !== 0}
+                >
+                    Approve
+                </button>
+                <button
+                    className="px-4 py-2 rounded-xl bg-blue-500 text-white disabled:opacity-50"
+                    disabled={
+                        txPending ||
+                        selected === null ||
+                        !amount ||
+                        votedId !== 0
+                    }
+                >
+                    投票する
+                </button>
+            </form>
+            {votedId !== 0 && (
+                <button
+                    className="px-4 py-2 rounded-xl bg-red-500 text-white disabled:opacity-50"
+                    disabled={txPending}
+                    onClick={cancelVote}
+                >
+                    取消
+                </button>
+            )}
+            {txPending && <p>トランザクション承認待ち…</p>}
+        </section>
+    );
+}
+
+export default WeightedVote;

--- a/simple-vote-ui/src/constants.js
+++ b/simple-vote-ui/src/constants.js
@@ -97,3 +97,138 @@ export const DYNAMIC_VOTE_ABI = [
 ];
 
 export const DYNAMIC_VOTE_ADDRESS = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+export const WEIGHTED_VOTE_ABI = [
+    {
+        inputs: [
+            { internalType: 'string', name: '_topic', type: 'string' },
+            { internalType: 'address', name: '_token', type: 'address' },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            { indexed: false, internalType: 'uint256', name: 'id', type: 'uint256' },
+            { indexed: false, internalType: 'string', name: 'name', type: 'string' },
+        ],
+        name: 'ChoiceAdded',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            { indexed: false, internalType: 'address', name: 'voter', type: 'address' },
+            { indexed: false, internalType: 'uint256', name: 'choiceId', type: 'uint256' },
+            { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'VoteCast',
+        type: 'event',
+    },
+    {
+        anonymous: false,
+        inputs: [
+            { indexed: true, internalType: 'address', name: 'voter', type: 'address' },
+            { indexed: false, internalType: 'uint256', name: 'choiceId', type: 'uint256' },
+            { indexed: false, internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'VoteCancelled',
+        type: 'event',
+    },
+    {
+        inputs: [{ internalType: 'string', name: 'name', type: 'string' }],
+        name: 'addChoice',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        name: 'choice',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'choiceCount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getChoices',
+        outputs: [{ internalType: 'string[]', name: 'names', type: 'string[]' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: '', type: 'address' }],
+        name: 'votedChoiceId',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'topic',
+        outputs: [{ internalType: 'string', name: '', type: 'string' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [
+            { internalType: 'uint256', name: 'choiceId', type: 'uint256' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'vote',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'cancelVote',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        name: 'voteCount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [{ internalType: 'address', name: '', type: 'address' }],
+        name: 'deposited',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'token',
+        outputs: [{ internalType: 'address', name: '', type: 'address' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+];
+
+export const WEIGHTED_VOTE_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export const ERC20_ABI = [
+    {
+        inputs: [
+            { internalType: 'address', name: 'spender', type: 'address' },
+            { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        name: 'approve',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+];

--- a/test/WeightedVote.js
+++ b/test/WeightedVote.js
@@ -1,0 +1,57 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('WeightedVote token deposit', function () {
+    let vote;
+    let token;
+    let owner;
+    let addr1;
+
+    beforeEach(async () => {
+        const Token = await ethers.getContractFactory('MockERC20');
+        const Vote = await ethers.getContractFactory('WeightedVote');
+        [owner, addr1] = await ethers.getSigners();
+        token = await Token.deploy('Mock', 'MCK');
+        await token.waitForDeployment();
+        await token.mint(owner.address, ethers.parseEther('1000'));
+        vote = await Vote.deploy('Best color', token.target);
+        await vote.waitForDeployment();
+        await vote.addChoice('Red');
+        await vote.addChoice('Blue');
+        await token.transfer(addr1.address, ethers.parseEther('100'));
+    });
+
+    it('投票時にトークンが減り、取消で戻る', async () => {
+        const amount = ethers.parseEther('10');
+        await token.connect(addr1).approve(vote.target, amount);
+        await vote.connect(addr1).vote(1, amount);
+        expect(await vote.voteCount(1)).to.equal(amount);
+        expect(await vote.deposited(addr1.address)).to.equal(amount);
+        expect(await token.balanceOf(addr1.address)).to.equal(
+            ethers.parseEther('90')
+        );
+        await vote.connect(addr1).cancelVote();
+        expect(await vote.voteCount(1)).to.equal(0n);
+        expect(await vote.deposited(addr1.address)).to.equal(0n);
+        expect(await token.balanceOf(addr1.address)).to.equal(
+            ethers.parseEther('100')
+        );
+    });
+
+    it('未投票でcancelVoteはrevert', async () => {
+        await expect(vote.connect(addr1).cancelVote()).to.be.revertedWith(
+            'No vote to cancel'
+        );
+    });
+
+    it('二重投票はできない', async () => {
+        const amount = ethers.parseEther('5');
+        await token.connect(addr1).approve(vote.target, amount);
+        await vote.connect(addr1).vote(1, amount);
+        await token.connect(addr1).approve(vote.target, amount);
+        await expect(
+            vote.connect(addr1).vote(1, amount)
+        ).to.be.revertedWith('Already voted. Cancel first');
+    });
+});
+


### PR DESCRIPTION
## Summary
- WeightedVote コントラクトを新規作成し、ERC20 預入れによる重み付き投票を実装
- テスト用 MockERC20 を追加
- WeightedVote の挙動を確認するテストを作成
- deploy スクリプトで WeightedVote とトークンをデプロイ

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ded66420833095f8963a1b9f1955