### PR TITLE
Add WeightedVote feature

### DIFF
--- a/contracts/WeightedToken.sol
+++ b/contracts/WeightedToken.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title WeightedToken
+ * @notice 投票の重み付けに利用するシンプルな ERC20 トークン
+ */
+contract WeightedToken is ERC20 {
+    constructor() ERC20("WeightedToken", "WVT") {
+        // 初期供給をデプロイアドレスへミント
+        _mint(msg.sender, 1_000_000 * 10 ** decimals());
+    }
+}

--- a/contracts/WeightedVote.sol
+++ b/contracts/WeightedVote.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title WeightedVote
+ * @notice ERC20 トークン量によって票の重みが決まる投票コントラクト
+ */
+contract WeightedVote {
+    /// 投票テーマ
+    string public topic;
+    /// 使用するトークン
+    IERC20 public immutable token;
+    /// 賛成票総数
+    uint256 public agree;
+    /// 反対票総数
+    uint256 public disagree;
+
+    /// アドレス => 投票した選択肢 (0:未投票, 1:賛成, 2:反対)
+    mapping(address => uint8) public votedChoiceId;
+    /// アドレス => 投票に使ったトークン量
+    mapping(address => uint256) public voteWeight;
+
+    event VoteCast(address indexed voter, bool agreeVote, uint256 amount);
+    event VoteCancelled(address indexed voter, uint256 amount);
+
+    constructor(string memory _topic, IERC20 _token) {
+        topic = _topic;
+        token = _token;
+    }
+
+    /// @notice 指定量のトークンを使って投票
+    function vote(bool agreeVote, uint256 amount) external {
+        require(votedChoiceId[msg.sender] == 0, "Already voted");
+        require(amount > 0, "amount zero");
+        votedChoiceId[msg.sender] = agreeVote ? 1 : 2;
+        voteWeight[msg.sender] = amount;
+        if (agreeVote) {
+            agree += amount;
+        } else {
+            disagree += amount;
+        }
+        require(token.transferFrom(msg.sender, address(this), amount), "transfer failed");
+        emit VoteCast(msg.sender, agreeVote, amount);
+    }
+
+    /// @notice 投票を取り消し、トークンを返却
+    function cancelVote() external {
+        uint8 prev = votedChoiceId[msg.sender];
+        require(prev != 0, "No vote to cancel");
+        uint256 amount = voteWeight[msg.sender];
+        if (prev == 1) {
+            agree -= amount;
+        } else if (prev == 2) {
+            disagree -= amount;
+        }
+        votedChoiceId[msg.sender] = 0;
+        voteWeight[msg.sender] = 0;
+        require(token.transfer(msg.sender, amount), "refund failed");
+        emit VoteCancelled(msg.sender, amount);
+    }
+
+    /// @notice 現在の賛成票数と反対票数を取得
+    function getVotes() external view returns (uint256, uint256) {
+        return (agree, disagree);
+    }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,12 +1,46 @@
 const hre = require('hardhat');
+const fs = require('fs');
+const path = require('path');
 
 async function main() {
+    // DynamicVote のデプロイ
     const Vote = await hre.ethers.getContractFactory('DynamicVote');
     const vote = await Vote.deploy('Cats vs Dogs');
     await vote.waitForDeployment();
     await vote.addChoice('Cats');
     await vote.addChoice('Dogs');
     console.log('DynamicVote deployed to:', vote.target);
+
+    // WeightedToken のデプロイ
+    const Token = await hre.ethers.getContractFactory('WeightedToken');
+    const token = await Token.deploy();
+    await token.waitForDeployment();
+    console.log('WeightedToken deployed to:', token.target);
+
+    // WeightedVote のデプロイ
+    const Weighted = await hre.ethers.getContractFactory('WeightedVote');
+    const weighted = await Weighted.deploy('Cats vs Dogs', token.target);
+    await weighted.waitForDeployment();
+    console.log('WeightedVote deployed to:', weighted.target);
+
+    // フロントエンド用定数ファイルを書き出し
+    const dynamicAbi = (await hre.artifacts.readArtifact('DynamicVote')).abi;
+    const weightedAbi = (await hre.artifacts.readArtifact('WeightedVote')).abi;
+
+    const outPath = path.join(__dirname, '..', 'simple-vote-ui', 'src', 'constants.js');
+    const content = `export const DYNAMIC_VOTE_ABI = ${JSON.stringify(dynamicAbi, null, 4)};
+export const DYNAMIC_VOTE_ADDRESS = '${vote.target}';
+export const WEIGHTED_VOTE_ABI = ${JSON.stringify(weightedAbi, null, 4)};
+export const WEIGHTED_VOTE_ADDRESS = '${weighted.target}';
+export const WEIGHTED_TOKEN_ADDRESS = '${token.target}';
+export const ERC20_ABI = [
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function allowance(address owner, address spender) external view returns (uint256)",
+    "function balanceOf(address account) external view returns (uint256)"
+];
+`;
+    fs.writeFileSync(outPath, content);
+    console.log('constants.js updated');
 }
 
 main().catch((error) => {

--- a/simple-vote-ui/src/constants.js
+++ b/simple-vote-ui/src/constants.js
@@ -1,99 +1,476 @@
 export const DYNAMIC_VOTE_ABI = [
     {
-        inputs: [{ internalType: 'string', name: '_topic', type: 'string' }],
-        stateMutability: 'nonpayable',
-        type: 'constructor',
-    },
-    {
-        anonymous: false,
-        inputs: [
-            { indexed: false, internalType: 'uint256', name: 'id', type: 'uint256' },
-            { indexed: false, internalType: 'string', name: 'name', type: 'string' },
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "_topic",
+                "type": "string"
+            }
         ],
-        name: 'ChoiceAdded',
-        type: 'event',
+        "stateMutability": "nonpayable",
+        "type": "constructor"
     },
     {
-        anonymous: false,
-        inputs: [
-            { indexed: false, internalType: 'address', name: 'voter', type: 'address' },
-            { indexed: false, internalType: 'uint256', name: 'choiceId', type: 'uint256' },
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
         ],
-        name: 'VoteCast',
-        type: 'event',
+        "name": "OwnableInvalidOwner",
+        "type": "error"
     },
     {
-        anonymous: false,
-        inputs: [
-            { indexed: false, internalType: 'address', name: 'voter', type: 'address' },
-            { indexed: false, internalType: 'uint256', name: 'choiceId', type: 'uint256' },
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+            }
         ],
-        name: 'VoteCancelled',
-        type: 'event',
+        "name": "OwnableUnauthorizedAccount",
+        "type": "error"
     },
     {
-        inputs: [{ internalType: 'string', name: 'name', type: 'string' }],
-        name: 'addChoice',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function',
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "id",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            }
+        ],
+        "name": "ChoiceAdded",
+        "type": "event"
     },
     {
-        inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        name: 'choice',
-        outputs: [{ internalType: 'string', name: '', type: 'string' }],
-        stateMutability: 'view',
-        type: 'function',
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "previousOwner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
     },
     {
-        inputs: [],
-        name: 'choiceCount',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "voter",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "choiceId",
+                "type": "uint256"
+            }
+        ],
+        "name": "VoteCancelled",
+        "type": "event"
     },
     {
-        inputs: [],
-        name: 'getChoices',
-        outputs: [{ internalType: 'string[]', name: 'names', type: 'string[]' }],
-        stateMutability: 'view',
-        type: 'function',
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "voter",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "choiceId",
+                "type": "uint256"
+            }
+        ],
+        "name": "VoteCast",
+        "type": "event"
     },
     {
-        inputs: [{ internalType: 'address', name: '', type: 'address' }],
-        name: 'votedChoiceId',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "name",
+                "type": "string"
+            }
+        ],
+        "name": "addChoice",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
     },
     {
-        inputs: [],
-        name: 'topic',
-        outputs: [{ internalType: 'string', name: '', type: 'string' }],
-        stateMutability: 'view',
-        type: 'function',
+        "inputs": [],
+        "name": "cancelVote",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
     },
     {
-        inputs: [{ internalType: 'uint256', name: 'choiceId', type: 'uint256' }],
-        name: 'vote',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function',
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "choice",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
     },
     {
-        inputs: [],
-        name: 'cancelVote',
-        outputs: [],
-        stateMutability: 'nonpayable',
-        type: 'function',
+        "inputs": [],
+        "name": "choiceCount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
     },
     {
-        inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        name: 'voteCount',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
+        "inputs": [],
+        "name": "getChoices",
+        "outputs": [
+            {
+                "internalType": "string[]",
+                "name": "names",
+                "type": "string[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
     },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "renounceOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "topic",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "choiceId",
+                "type": "uint256"
+            }
+        ],
+        "name": "vote",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "voteCount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "votedChoiceId",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
 ];
-
 export const DYNAMIC_VOTE_ADDRESS = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+export const WEIGHTED_VOTE_ABI = [
+    {
+        "inputs": [
+            {
+                "internalType": "string",
+                "name": "_topic",
+                "type": "string"
+            },
+            {
+                "internalType": "contract IERC20",
+                "name": "_token",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "voter",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "VoteCancelled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "voter",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "agreeVote",
+                "type": "bool"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "VoteCast",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "agree",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "cancelVote",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "disagree",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getVotes",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "token",
+        "outputs": [
+            {
+                "internalType": "contract IERC20",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "topic",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bool",
+                "name": "agreeVote",
+                "type": "bool"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "vote",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "voteWeight",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "votedChoiceId",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+];
+export const WEIGHTED_VOTE_ADDRESS = '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9';
+export const WEIGHTED_TOKEN_ADDRESS = '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9';
+export const ERC20_ABI = [
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function allowance(address owner, address spender) external view returns (uint256)",
+    "function balanceOf(address account) external view returns (uint256)"
+];


### PR DESCRIPTION
## Summary
- WeightedTokenとWeightedVoteコントラクトを追加
- デプロイスクリプトでWeighted系コントラクトをデプロイし定数更新
- UIにWeightedVoteパネルを実装しapprove/vote/cancelに対応
- フロントエンド定数を自動生成

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685817036fc483309db37e81aba97cd7