### PR TITLE
Add time-limited voting

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,7 +4,10 @@ const path = require('path');
 
 async function main() {
     const Vote = await hre.ethers.getContractFactory('DynamicVote');
-    const vote = await Vote.deploy('Cats vs Dogs');
+    const now = Math.floor(Date.now() / 1000);
+    const start = now + 60; // 1 分後に開始
+    const end = start + 3600; // 1 時間投票可能
+    const vote = await Vote.deploy('Cats vs Dogs', start, end);
     await vote.waitForDeployment();
     await vote.addChoice('Cats');
     await vote.addChoice('Dogs');

--- a/simple-vote-ui/src/constants.js
+++ b/simple-vote-ui/src/constants.js
@@ -1,6 +1,10 @@
 export const DYNAMIC_VOTE_ABI = [
     {
-        inputs: [{ internalType: 'string', name: '_topic', type: 'string' }],
+        inputs: [
+            { internalType: 'string', name: '_topic', type: 'string' },
+            { internalType: 'uint256', name: '_start', type: 'uint256' },
+            { internalType: 'uint256', name: '_end', type: 'uint256' },
+        ],
         stateMutability: 'nonpayable',
         type: 'constructor',
     },
@@ -54,6 +58,20 @@ export const DYNAMIC_VOTE_ABI = [
     },
     {
         inputs: [],
+        name: 'startTime',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'endTime',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
         name: 'getChoices',
         outputs: [{ internalType: 'string[]', name: 'names', type: 'string[]' }],
         stateMutability: 'view',
@@ -91,6 +109,23 @@ export const DYNAMIC_VOTE_ABI = [
         inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
         name: 'voteCount',
         outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'getPeriod',
+        outputs: [
+            { internalType: 'uint256', name: '', type: 'uint256' },
+            { internalType: 'uint256', name: '', type: 'uint256' },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'isOpen',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
         stateMutability: 'view',
         type: 'function',
     },


### PR DESCRIPTION
## Summary
- DynamicVote contract now accepts start and end time
- reject voting outside the period
- expose period related view functions
- adapt deployment script and ABI
- add tests for open/close conditions

## Testing
- `npm run lint` in `simple-vote-ui`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857dc8d97f88330829d8a45d9b88c42