### PR TITLE
Add voting period to SimpleVote

### DIFF
--- a/contracts/SimpleVote.sol
+++ b/contracts/SimpleVote.sol
@@ -28,6 +28,8 @@ contract SimpleVote {
     string public topic;   // 投票テーマ。public 修飾子で自動 Getter が生成される
     uint   public agree;   // 賛成票のカウンタ
     uint   public disagree;// 反対票のカウンタ
+    uint256 public startTime; // 投票開始時刻
+    uint256 public endTime;   // 投票終了時刻
 
     // アドレス => 投票した選択肢 ID (0: 未投票, 1: 賛成, 2: 反対)
     mapping(address => uint) public votedChoiceId;
@@ -40,8 +42,11 @@ contract SimpleVote {
     // 🔸 コンストラクタ
     // =============================
     // デプロイ時に投票テーマを受け取り、状態変数 topic に保存します。
-    constructor(string memory _topic) {
+    constructor(string memory _topic, uint256 _startTime, uint256 _endTime) {
+        require(_endTime > _startTime, "end must be after start");
         topic = _topic;
+        startTime = _startTime;
+        endTime = _endTime;
     }
 
     // =============================
@@ -50,6 +55,10 @@ contract SimpleVote {
     /// @notice 賛成( true ) か 反対( false ) を送信者が投票します。
     /// @param agreeVote true で賛成、false で反対。
     function vote(bool agreeVote) external {
+        require(
+            block.timestamp >= startTime && block.timestamp <= endTime,
+            "Voting closed"
+        );
         require(votedChoiceId[msg.sender] == 0, "Already voted. Cancel first");
 
         if (agreeVote) {
@@ -63,6 +72,10 @@ contract SimpleVote {
 
     /// @notice 投票を取り消します
     function cancelVote() external {
+        require(
+            block.timestamp >= startTime && block.timestamp <= endTime,
+            "Voting closed"
+        );
         uint prev = votedChoiceId[msg.sender];
         require(prev != 0, "No vote to cancel");
         if (prev == 1) {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,7 +4,10 @@ const path = require('path');
 
 async function main() {
     const Vote = await hre.ethers.getContractFactory('DynamicVote');
-    const vote = await Vote.deploy('Cats vs Dogs');
+    const now = Math.floor(Date.now() / 1000);
+    const start = now + 60;
+    const end = start + 3600;
+    const vote = await Vote.deploy('Cats vs Dogs', start, end);
     await vote.waitForDeployment();
     await vote.addChoice('Cats');
     await vote.addChoice('Dogs');

--- a/simple-vote-ui/src/App.jsx
+++ b/simple-vote-ui/src/App.jsx
@@ -11,6 +11,8 @@ function App() {
     const [selected, setSelected] = useState(null);
     const [votedId, setVotedId] = useState(0);
     const [txPending, setTxPending] = useState(false);
+    const [start, setStart] = useState(0);
+    const [end, setEnd] = useState(0);
 
     /** ① MetaMask へ接続 */
     const connectWallet = async () => {
@@ -34,6 +36,8 @@ function App() {
     const fetchData = useCallback(async () => {
         if (!contract) return;
         setTopic(await contract.topic());
+        setStart(Number(await contract.startTime()));
+        setEnd(Number(await contract.endTime()));
         const count = await contract.choiceCount();
         const arr = [];
         for (let i = 1n; i <= count; i++) {
@@ -112,6 +116,12 @@ function App() {
             ) : (
                 <>
                     <p className="text-lg">議題: {topic}</p>
+                    <p>
+                        開始: {start ? new Date(start * 1000).toLocaleString() : '-'}
+                    </p>
+                    <p>
+                        終了: {end ? new Date(end * 1000).toLocaleString() : '-'}
+                    </p>
 
                     <form
                         className="flex flex-col gap-2"

--- a/simple-vote-ui/src/constants.js
+++ b/simple-vote-ui/src/constants.js
@@ -1,6 +1,10 @@
 export const DYNAMIC_VOTE_ABI = [
     {
-        inputs: [{ internalType: 'string', name: '_topic', type: 'string' }],
+        inputs: [
+            { internalType: 'string', name: '_topic', type: 'string' },
+            { internalType: 'uint256', name: '_startTime', type: 'uint256' },
+            { internalType: 'uint256', name: '_endTime', type: 'uint256' },
+        ],
         stateMutability: 'nonpayable',
         type: 'constructor',
     },
@@ -90,6 +94,20 @@ export const DYNAMIC_VOTE_ABI = [
     {
         inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
         name: 'voteCount',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'startTime',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+    },
+    {
+        inputs: [],
+        name: 'endTime',
         outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
         stateMutability: 'view',
         type: 'function',

--- a/test/DynamicVote.js
+++ b/test/DynamicVote.js
@@ -1,19 +1,25 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
 
 describe('DynamicVote cancel/revote', function () {
     let vote;
     let owner;
     let addr1;
     let addr2;
+    let start;
+    let end;
 
     beforeEach(async () => {
         const Vote = await ethers.getContractFactory('DynamicVote');
         [owner, addr1, addr2] = await ethers.getSigners();
-        vote = await Vote.deploy('Favorite fruit');
+        start = (await time.latest()) + 10;
+        end = start + 3600;
+        vote = await Vote.deploy('Favorite fruit', start, end);
         await vote.waitForDeployment();
         await vote.addChoice('Apple');
         await vote.addChoice('Orange');
+        await time.increaseTo(start + 1);
     });
 
     it('初期トピックが正しい', async () => {
@@ -53,5 +59,31 @@ describe('DynamicVote cancel/revote', function () {
         await expect(vote.connect(addr1).vote(1)).to.be.revertedWith(
             'Already voted. Cancel first'
         );
+    });
+
+    it('開始前は投票できない', async () => {
+        const Vote = await ethers.getContractFactory('DynamicVote');
+        const now = await time.latest();
+        const s = now + 100;
+        const e = s + 3600;
+        const v = await Vote.deploy('Fruit', s, e);
+        await v.waitForDeployment();
+        await v.addChoice('Apple');
+        await expect(v.connect(addr1).vote(1)).to.be.revertedWith('Voting closed');
+    });
+
+    it('終了後は投票も取消もできない', async () => {
+        const Vote = await ethers.getContractFactory('DynamicVote');
+        const now = await time.latest();
+        const s = now + 3;
+        const e = s + 4;
+        const v = await Vote.deploy('Fruit', s, e);
+        await v.waitForDeployment();
+        await v.addChoice('Apple');
+        await time.increaseTo(s + 1);
+        await v.connect(addr1).vote(1);
+        await time.increaseTo(e + 1);
+        await expect(v.connect(addr1).vote(1)).to.be.revertedWith('Voting closed');
+        await expect(v.connect(addr1).cancelVote()).to.be.revertedWith('Voting closed');
     });
 });

--- a/test/SimpleVote.js
+++ b/test/SimpleVote.js
@@ -1,16 +1,22 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
 
 describe('SimpleVote cancel/revote', function () {
     let vote;
     let owner;
     let addr1;
+    let start;
+    let end;
 
     beforeEach(async () => {
         const Vote = await ethers.getContractFactory('SimpleVote');
         [owner, addr1] = await ethers.getSigners();
-        vote = await Vote.deploy('Cats vs Dogs');
+        start = (await time.latest()) + 10;
+        end = start + 3600;
+        vote = await Vote.deploy('Cats vs Dogs', start, end);
         await vote.waitForDeployment();
+        await time.increaseTo(start + 1);
     });
 
     it('初期トピックが正しい', async () => {
@@ -48,5 +54,29 @@ describe('SimpleVote cancel/revote', function () {
         const [agree, disagree] = await vote.getVotes();
         expect(agree).to.equal(1n);
         expect(disagree).to.equal(0n);
+    });
+
+    it('開始前は投票できない', async () => {
+        const Vote = await ethers.getContractFactory('SimpleVote');
+        const now = await time.latest();
+        const s = now + 100;
+        const e = s + 3600;
+        const v = await Vote.deploy('Cats vs Dogs', s, e);
+        await v.waitForDeployment();
+        await expect(v.connect(addr1).vote(true)).to.be.revertedWith('Voting closed');
+    });
+
+    it('終了後は投票も取消もできない', async () => {
+        const Vote = await ethers.getContractFactory('SimpleVote');
+        const now = await time.latest();
+        const s = now + 1;
+        const e = s + 10;
+        const v = await Vote.deploy('Cats vs Dogs', s, e);
+        await v.waitForDeployment();
+        await time.increaseTo(s + 1);
+        await v.connect(addr1).vote(true);
+        await time.increaseTo(e + 1);
+        await expect(v.connect(addr1).vote(true)).to.be.revertedWith('Voting closed');
+        await expect(v.connect(addr1).cancelVote()).to.be.revertedWith('Voting closed');
     });
 });


### PR DESCRIPTION
## Summary
- 投票開始と終了の時刻を管理する startTime/endTime を追加
- vote と cancelVote に投票期間チェックを実装
- 期間外の挙動を確認するテストケースを追加

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858f28a6df0833091d41d6f33ca2696