### PR TITLE
feat: トーストで処理状況を表示

### DIFF
--- a/simple-vote-ui/src/Toast.jsx
+++ b/simple-vote-ui/src/Toast.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+// シンプルなトースト表示用コンポーネント
+function Toast({ message, onClose }) {
+    // 自動的に 3 秒後に閉じる
+    useEffect(() => {
+        const timer = setTimeout(onClose, 3000);
+        return () => clearTimeout(timer);
+    }, [onClose]);
+
+    return (
+        <div className="toast">
+            {message}
+        </div>
+    );
+}
+
+export default Toast;

--- a/simple-vote-ui/src/WeightedVote.jsx
+++ b/simple-vote-ui/src/WeightedVote.jsx
@@ -6,7 +6,7 @@ import {
     ERC20_ABI,
 } from './constants';
 
-function WeightedVote({ signer }) {
+function WeightedVote({ signer, showToast }) {
     const [contract, setContract] = useState(null);
     const [token, setToken] = useState(null);
     const [topic, setTopic] = useState('');
@@ -81,8 +81,10 @@ function WeightedVote({ signer }) {
     const approve = async () => {
         if (!token || !amount) return;
         const value = ethers.parseEther(amount);
+        showToast('トランザクション承認待ち…');
         const tx = await token.approve(WEIGHTED_VOTE_ADDRESS, value);
         await tx.wait();
+        showToast('承認が完了しました');
     };
 
     // 投票処理
@@ -90,10 +92,12 @@ function WeightedVote({ signer }) {
         if (!contract || selected === null || !amount) return;
         try {
             setTxPending(true);
+            showToast('トランザクション承認待ち…');
             const value = ethers.parseEther(amount);
             const tx = await contract.vote(selected, value);
             await tx.wait();
             await fetchData();
+            showToast('投票が完了しました');
         } finally {
             setTxPending(false);
         }
@@ -104,9 +108,11 @@ function WeightedVote({ signer }) {
         if (!contract) return;
         try {
             setTxPending(true);
+            showToast('トランザクション承認待ち…');
             const tx = await contract.cancelVote();
             await tx.wait();
             await fetchData();
+            showToast('投票を取り消しました');
         } finally {
             setTxPending(false);
         }
@@ -174,7 +180,6 @@ function WeightedVote({ signer }) {
                     取消
                 </button>
             )}
-            {txPending && <p>トランザクション承認待ち…</p>}
         </section>
     );
 }

--- a/simple-vote-ui/src/index.css
+++ b/simple-vote-ui/src/index.css
@@ -66,3 +66,21 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+/* トースト表示用 */
+.toast-container {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1000;
+}
+
+.toast {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## 変更点
- Toastコンポーネントを追加し、共通スタイルを`index.css`に追記
- Appコンポーネントでトーストの状態管理を実装
- WeightedVoteとAppからトーストを利用するよう変更
- 不要になったステータス表示を削除

## テスト結果
- `npm test`：成功
- `npm run lint`：成功


------
https://chatgpt.com/codex/tasks/task_e_685a1ec5e9c08330a5e54f8b90ef2fd4