### PR TITLE
fix: コントラクト存在チェックを追加

### DIFF
--- a/simple-vote-ui/src/App.jsx
+++ b/simple-vote-ui/src/App.jsx
@@ -37,11 +37,20 @@ function App() {
             const _provider = new ethers.BrowserProvider(window.ethereum);
             await _provider.send('eth_requestAccounts', []);
             const _signer = await _provider.getSigner();
+
+            // ネットワーク上にコントラクトが存在するか確認
+            const code = await _provider.getCode(DYNAMIC_VOTE_ADDRESS);
+            if (code === '0x') {
+                showToast('指定のネットワークに DynamicVote がデプロイされていません');
+                return;
+            }
+
             const _contract = new ethers.Contract(
                 DYNAMIC_VOTE_ADDRESS,
                 DYNAMIC_VOTE_ABI,
-                _signer
+                _signer,
             );
+
             setSigner(_signer);
             setContract(_contract);
             showToast('ウォレット接続完了');

--- a/simple-vote-ui/src/WeightedVote.jsx
+++ b/simple-vote-ui/src/WeightedVote.jsx
@@ -18,19 +18,32 @@ function WeightedVote({ signer, showToast }) {
 
     // signer が変わったらコントラクトを初期化
     useEffect(() => {
-        if (!signer) return;
-        // アドレスが 0 の場合はコントラクトが未配置とみなす
-        if (WEIGHTED_VOTE_ADDRESS === '0x0000000000000000000000000000000000000000') {
-            console.warn('WeightedVote コントラクトアドレスが未設定です');
-            return;
-        }
-        const vote = new ethers.Contract(
-            WEIGHTED_VOTE_ADDRESS,
-            WEIGHTED_VOTE_ABI,
-            signer
-        );
-        setContract(vote);
         (async () => {
+            if (!signer) return;
+
+            // コントラクトアドレスが設定されているか確認
+            if (
+                WEIGHTED_VOTE_ADDRESS ===
+                '0x0000000000000000000000000000000000000000'
+            ) {
+                console.warn('WeightedVote コントラクトアドレスが未設定です');
+                return;
+            }
+
+            // 現在のネットワークにデプロイされているか確認
+            const code = await signer.provider.getCode(WEIGHTED_VOTE_ADDRESS);
+            if (code === '0x') {
+                console.warn('WeightedVote コントラクトが見つかりません');
+                return;
+            }
+
+            const vote = new ethers.Contract(
+                WEIGHTED_VOTE_ADDRESS,
+                WEIGHTED_VOTE_ABI,
+                signer,
+            );
+            setContract(vote);
+
             const tokenAddr = await vote.token();
             const tok = new ethers.Contract(tokenAddr, ERC20_ABI, signer);
             setToken(tok);


### PR DESCRIPTION
## 変更点
- ウォレット接続時に `DynamicVote` がネットワーク上に存在するか確認
- `WeightedVote` でも同様にコードの有無を調べ、未デプロイなら処理を中断

## テスト結果
- `npm run lint` を実行しエラーが無いことを確認


------
https://chatgpt.com/codex/tasks/task_e_685b9dff2b988330964727544b6b7c78