### PR TITLE
投票期間の追加とテスト更新

### DIFF
--- a/contracts/WeightedVote.sol
+++ b/contracts/WeightedVote.sol
@@ -14,6 +14,10 @@ contract WeightedVote is Ownable {
     IERC20 public immutable token;
     /// 議題
     string public topic;
+    /// 投票開始時刻（変更不可）
+    uint256 public immutable startTime;
+    /// 投票終了時刻（変更不可）
+    uint256 public immutable endTime;
     /// 選択肢 ID => 選択肢名
     mapping(uint256 => string) public choice;
     /// アドレス => 投票した選択肢 ID (0 は未投票)
@@ -31,9 +35,19 @@ contract WeightedVote is Ownable {
 
     /// @param _topic 議題
     /// @param _token 投票に利用する ERC20 トークン
-    constructor(string memory _topic, IERC20 _token) Ownable(msg.sender) {
+    /// @param _startTime 投票開始時刻
+    /// @param _endTime 投票終了時刻
+    constructor(
+        string memory _topic,
+        IERC20 _token,
+        uint256 _startTime,
+        uint256 _endTime
+    ) Ownable(msg.sender) {
+        require(_endTime > _startTime, "end must be after start");
         topic = _topic;
         token = _token;
+        startTime = _startTime;
+        endTime = _endTime;
     }
 
     /**
@@ -53,6 +67,10 @@ contract WeightedVote is Ownable {
      * @param amount 預けるトークン量（そのまま票数となります）
      */
     function vote(uint256 choiceId, uint256 amount) external {
+        require(
+            block.timestamp >= startTime && block.timestamp <= endTime,
+            "Voting closed"
+        );
         require(votedChoiceId[msg.sender] == 0, "Already voted. Cancel first");
         require(choiceId > 0 && choiceId <= choiceCount, "invalid id");
         require(amount > 0, "amount zero");
@@ -66,6 +84,10 @@ contract WeightedVote is Ownable {
 
     /// @notice 投票を取り消し、預けたトークンを返却します
     function cancelVote() external {
+        require(
+            block.timestamp >= startTime && block.timestamp <= endTime,
+            "Voting closed"
+        );
         uint256 prev = votedChoiceId[msg.sender];
         require(prev != 0, "No vote to cancel");
         uint256 amount = deposited[msg.sender];

--- a/test/WeightedVote.js
+++ b/test/WeightedVote.js
@@ -1,11 +1,14 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
 
 describe('WeightedVote token deposit', function () {
     let vote;
     let token;
     let owner;
     let addr1;
+    let start;
+    let end;
 
     beforeEach(async () => {
         const Token = await ethers.getContractFactory('MockERC20');
@@ -14,11 +17,14 @@ describe('WeightedVote token deposit', function () {
         token = await Token.deploy('Mock', 'MCK');
         await token.waitForDeployment();
         await token.mint(owner.address, ethers.parseEther('1000'));
-        vote = await Vote.deploy('Best color', token.target);
+        start = (await time.latest()) + 10;
+        end = start + 3600;
+        vote = await Vote.deploy('Best color', token.target, start, end);
         await vote.waitForDeployment();
         await vote.addChoice('Red');
         await vote.addChoice('Blue');
         await token.transfer(addr1.address, ethers.parseEther('100'));
+        await time.increaseTo(start + 1);
     });
 
     it('投票時にトークンが減り、取消で戻る', async () => {
@@ -52,6 +58,51 @@ describe('WeightedVote token deposit', function () {
         await expect(
             vote.connect(addr1).vote(1, amount)
         ).to.be.revertedWith('Already voted. Cancel first');
+    });
+
+    it('開始前は投票できない', async () => {
+        const Token = await ethers.getContractFactory('MockERC20');
+        const Vote = await ethers.getContractFactory('WeightedVote');
+        const now = await time.latest();
+        const s = now + 100;
+        const e = s + 3600;
+        const t = await Token.deploy('Mock', 'MCK');
+        await t.waitForDeployment();
+        await t.mint(owner.address, ethers.parseEther('10'));
+        const v = await Vote.deploy('Color', t.target, s, e);
+        await v.waitForDeployment();
+        await v.addChoice('Red');
+        await t.transfer(addr1.address, ethers.parseEther('1'));
+        await t.connect(addr1).approve(v.target, ethers.parseEther('1'));
+        await expect(v.connect(addr1).vote(1, ethers.parseEther('1'))).to.be.revertedWith(
+            'Voting closed'
+        );
+    });
+
+    it('終了後は投票も取消もできない', async () => {
+        const Token = await ethers.getContractFactory('MockERC20');
+        const Vote = await ethers.getContractFactory('WeightedVote');
+        const now = await time.latest();
+        const s = now + 100;
+        const e = s + 10;
+        const t = await Token.deploy('Mock', 'MCK');
+        await t.waitForDeployment();
+        await t.mint(owner.address, ethers.parseEther('10'));
+        const v = await Vote.deploy('Color', t.target, s, e);
+        await v.waitForDeployment();
+        await v.addChoice('Red');
+        await time.increaseTo(s + 2);
+        await t.transfer(addr1.address, ethers.parseEther('1'));
+        await t.connect(addr1).approve(v.target, ethers.parseEther('1'));
+        await v.connect(addr1).vote(1, ethers.parseEther('1'));
+        await time.increaseTo(e + 1);
+        await t.connect(addr1).approve(v.target, ethers.parseEther('1'));
+        await expect(v.connect(addr1).vote(1, ethers.parseEther('1'))).to.be.revertedWith(
+            'Voting closed'
+        );
+        await expect(v.connect(addr1).cancelVote()).to.be.revertedWith(
+            'Voting closed'
+        );
     });
 });
 


### PR DESCRIPTION
## 変更点
- WeightedVote コントラクトに投票開始・終了時刻を導入
- `vote` と `cancelVote` が期間外では `Voting closed` で revert
- 開始・終了時刻をコンストラクタで設定し、immutalbe に変更
- WeightedVote.js のテストを更新し、期限チェックを追加

## テスト結果
- `npm test` を実行し 29 件すべて成功


------
https://chatgpt.com/codex/tasks/task_e_685d103bcde48330a2a1686882ab8576