### PR TITLE
デプロイスクリプトの改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ npm test
 
 ## コントラクトデプロイ
 
-ネットワーク情報は `hardhat.config.js` の `networks` セクションで指定します。 `.env` に設定したアカウントでデプロイを実行します。
+`scripts/deploy.js` を実行すると PollManager とサンプル投票(DynamicVote、WeightedVote) がデプロイされ、
+`simple-vote-ui/src/constants.js` のアドレス定数が自動更新されます。
+
+ネットワークは `hardhat.config.js` の `networks` から選択し、`.env` に指定したアカウントで実行してください。
 
 ```bash
 npx hardhat run scripts/deploy.js --network amoy

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -13,11 +13,15 @@ async function main() {
 
     // フロントエンドのアドレス書き換え設定
     const constantsPath = path.join(__dirname, '..', 'simple-vote-ui', 'src', 'constants.js');
+
+    // ファイルを読み込み後でアドレスを書き換える関数
+    const updateConstant = (content, key, value) => {
+        const regex = new RegExp(`export const ${key} = '0x[0-9a-fA-F]+';`);
+        return content.replace(regex, `export const ${key} = '${value}';`);
+    };
+
     let data = fs.readFileSync(constantsPath, 'utf8');
-    data = data.replace(
-        /export const POLL_MANAGER_ADDRESS = '0x[0-9a-fA-F]+';/,
-        `export const POLL_MANAGER_ADDRESS = '${manager.target}';`
-    );
+    data = updateConstant(data, 'POLL_MANAGER_ADDRESS', manager.target);
     fs.writeFileSync(constantsPath, data);
     console.log('Updated POLL_MANAGER_ADDRESS in constants.js');
 
@@ -57,14 +61,8 @@ async function main() {
 
     // 生成したアドレスをフロントエンドに反映
     data = fs.readFileSync(constantsPath, 'utf8');
-    data = data.replace(
-        /export const DYNAMIC_VOTE_ADDRESS = '0x[0-9a-fA-F]+';/,
-        `export const DYNAMIC_VOTE_ADDRESS = '${dynamic.target}';`
-    );
-    data = data.replace(
-        /export const WEIGHTED_VOTE_ADDRESS = '0x[0-9a-fA-F]+';/,
-        `export const WEIGHTED_VOTE_ADDRESS = '${weighted.target}';`
-    );
+    data = updateConstant(data, 'DYNAMIC_VOTE_ADDRESS', dynamic.target);
+    data = updateConstant(data, 'WEIGHTED_VOTE_ADDRESS', weighted.target);
     fs.writeFileSync(constantsPath, data);
     console.log('Updated vote addresses in constants.js');
 


### PR DESCRIPTION
## 概要
- PollManager と各投票コントラクトのアドレスを自動で書き換える処理を追加
- README に新しいデプロイ手順を追記

## テスト結果
- `npm test` は Hardhat のコンパイラ取得ができず失敗


------
https://chatgpt.com/codex/tasks/task_e_685ee2d055c883308e33e7b39fc7dc28