### PR TITLE
SafeERC20 の導入

### DIFF
--- a/contracts/WeightedVote.sol
+++ b/contracts/WeightedVote.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
  * @title WeightedVote
@@ -10,6 +11,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * DynamicVote を基に、投票時に ERC20 トークンを預け入れます。
  */
 contract WeightedVote is Ownable {
+    using SafeERC20 for IERC20;
     /// 投票に使うトークン
     IERC20 public immutable token;
     /// 議題
@@ -57,7 +59,8 @@ contract WeightedVote is Ownable {
         require(choiceId > 0 && choiceId <= choiceCount, "invalid id");
         require(amount > 0, "amount zero");
 
-        require(token.transferFrom(msg.sender, address(this), amount));
+        // SafeERC20 を使って転送失敗を確実に検知する
+        token.safeTransferFrom(msg.sender, address(this), amount);
         voteCount[choiceId] += amount;
         deposited[msg.sender] = amount;
         votedChoiceId[msg.sender] = choiceId;
@@ -72,7 +75,8 @@ contract WeightedVote is Ownable {
         voteCount[prev] -= amount;
         deposited[msg.sender] = 0;
         votedChoiceId[msg.sender] = 0;
-        require(token.transfer(msg.sender, amount));
+        // 預けたトークンを安全に返却
+        token.safeTransfer(msg.sender, amount);
         emit VoteCancelled(msg.sender, prev, amount);
     }
 


### PR DESCRIPTION
## 変更点
- WeightedVote コントラクトで SafeERC20 を利用
- vote と cancelVote のトークン転送処理を安全化

## テスト結果
- `npm test` は Hardhat のコンパイラダウンロードに失敗 (ネットワーク制限)


------
https://chatgpt.com/codex/tasks/task_e_685eed2aaad883308f0f45c502b3f745