### PR TITLE
デプロイ手順の説明更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ npm test
 
 ## コントラクトデプロイ
 
-ネットワーク情報は `hardhat.config.js` の `networks` セクションで指定します。 `.env` に設定したアカウントでデプロイを実行します。
+このリポジトリでは Polygon の Amoy テストネットを `amoy` ネットワークとして設定しています。
+`.env` には Amoy の RPC URL とデプロイに使用する秘密鍵を入力してください。
+準備ができたら以下のコマンドでデプロイを実行します。
 
 ```bash
 npx hardhat run scripts/deploy.js --network amoy


### PR DESCRIPTION
## 変更内容
- README のコントラクトデプロイ手順を修正し、Amoy テストネットを使用する説明を追記しました。

## テスト結果
- `npm test` を実行しましたが、Solidity コンパイラの取得に失敗しました。
  環境による制限が原因と思われます。

------
https://chatgpt.com/codex/tasks/task_e_685eed63e1e88330b6a8404ab55db395