### PR TITLE
feat: 新規作成画面に戻るボタンを追加

### DIFF
--- a/simple-vote-ui/src/App.jsx
+++ b/simple-vote-ui/src/App.jsx
@@ -57,6 +57,7 @@ function App() {
                     signer={signer}
                     onCreated={() => setPage('list')}
                     showToast={showToast}
+                    onBack={() => setPage('list')}
                 />
             );
         }

--- a/simple-vote-ui/src/PollCreate.jsx
+++ b/simple-vote-ui/src/PollCreate.jsx
@@ -11,7 +11,7 @@ import {
 const ZERO = '0x0000000000000000000000000000000000000000';
 
 // PollManager を使って DynamicVote か WeightedVote を作成するフォーム
-function PollCreate({ signer, onCreated, showToast }) {
+function PollCreate({ signer, onCreated, showToast, onBack }) {
     const [manager, setManager] = useState(null);
     const [pollType, setPollType] = useState('dynamic');
     const [topic, setTopic] = useState('');
@@ -215,6 +215,15 @@ function PollCreate({ signer, onCreated, showToast }) {
             >
                 作成
             </button>
+            {onBack && (
+                <button
+                    type="button"
+                    className="px-4 py-2 rounded-xl bg-gray-400 text-white"
+                    onClick={onBack}
+                >
+                    戻る
+                </button>
+            )}
         </form>
     );
 }


### PR DESCRIPTION
新規作成画面 (`PollCreate.jsx`)
に「戻る」ボタンを追加しました。これにより、ユーザーは投票作成を中断して一覧ペー
ジに戻ることができるようになります。

#### 変更点の詳細

-   `simple-vote-ui/src/PollCreate.jsx`:
    -   `onBack` プロパティを受け取るように変更しました。
    -   フォームの下部に「戻る」ボタンを追加し、クリック時に `onBack`
プロパティで渡された関数を呼び出すように設定しました。
    -   ボタンの表示は `onBack` プロパティが渡された場合にのみ行われます。
-   `simple-vote-ui/src/App.jsx`:
    -   `PollCreate` コンポーネントを呼び出す際に、`onBack` プロパティに `() =>
setPage('list')`
を渡すように変更しました。これにより、「戻る」ボタンがクリックされると、アプリケ
ーションのページが一覧表示 (`list`) に切り替わります。

#### 目的

-   ユーザーエクスペリエンスの向上:
ユーザーが簡単に前の画面に戻れるようにすることで、操作の柔軟性を高めます。

#### 確認事項

-   ローカル環境で動作確認済みです。
-「新規作成」画面から「戻る」ボタンをクリックすると、正しく一覧ページに戻ることを
確認しました。